### PR TITLE
fix(Docker): resolved Docker errors

### DIFF
--- a/Cdn.Dockerfile
+++ b/Cdn.Dockerfile
@@ -4,7 +4,8 @@ COPY --from=ghcr.io/skyra-project/grpc-protofiles:latest . .
 
 WORKDIR /skyra/app
 
-COPY sources ./
+COPY sources .
+COPY Directory.Build.props .
 
 RUN dotnet publish Cdn -r linux-x64 -p:PublishSingleFile=true -p:DebugType=None --self-contained true -c Release -o out
 

--- a/Notifications.Dockerfile
+++ b/Notifications.Dockerfile
@@ -4,7 +4,8 @@ COPY --from=ghcr.io/skyra-project/grpc-protofiles:latest . .
 
 WORKDIR /skyra/app
 
-COPY sources ./
+COPY sources .
+COPY Directory.Build.props .
 
 RUN dotnet publish Notifications -r linux-x64 -p:PublishSingleFile=true -p:DebugType=None --self-contained true -c Release -o out
 


### PR DESCRIPTION
The props needed the root's props, but they weren't copied, so a cryptic error was thrown instead.
