### PR TITLE
chore(docker): make lighter images

### DIFF
--- a/Cdn.Dockerfile
+++ b/Cdn.Dockerfile
@@ -13,7 +13,7 @@ RUN dotnet publish Cdn -p:PublishTrimmed=true -p:PublishSingleFile=true -p:Debug
 #   Runner Stage   #
 # ================ #
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
 
 WORKDIR /skyra/app
 

--- a/Notifications.Dockerfile
+++ b/Notifications.Dockerfile
@@ -13,7 +13,7 @@ RUN dotnet publish Notifications -p:PublishTrimmed=true -p:PublishSingleFile=tru
 #   Runner Stage   #
 # ================ #
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0
 
 WORKDIR /skyra/app
 


### PR DESCRIPTION
`mcr.microsoft.com/dotnet/runtime-deps:6.0` does not install .NET, ASP.NET, nor PWSH, which results on an image size decrease from 253.7 MB to 163.6 MB.

We didn't need them anyways, since we make a self-contained binary in the BUILDER step.
